### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 authors = ["Graydon Hoare <graydon@pobox.com>"]
 license = "MIT OR Apache-2.0"
 keywords = ["compression", "encoding", "dictionary"]
-repository = "http://github.com/graydon/ordbog"
+repository = "https://github.com/graydon/ordbog"
 readme = "README.md"
 
 [dependencies]


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97